### PR TITLE
Revert back to go implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,129 +1,28 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
+# Created by https://www.toptal.com/developers/gitignore/api/go
+# Edit at https://www.toptal.com/developers/gitignore?templates=go
 
-# C extensions
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
 *.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
+*.dylib
 dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-pip-wheel-metadata/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
+# Test binary, built with `go test -c`
+*.test
 
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
 
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
+# Dependency directories (remove the comment below to include it)
+# vendor/
 
-# Translations
-*.mo
-*.pot
+# Go workspace file
+go.work
 
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
+# End of https://www.toptal.com/developers/gitignore/api/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,8 @@
-FROM --platform=$TARGETPLATFORM python:3.8-alpine
+# FROM --platform=$TARGETPLATFORM golang:alpine
+FROM alpine
 
 MAINTAINER sntshkmr60@gmail.com
 
-WORKDIR /app
+COPY dist/cotu /usr/bin/cotu
 
-COPY requirements.txt requirements.txt
-
-RUN pip3 install -r requirements.txt
-
-COPY . .
-
-CMD [ "python3", "cotu.py"]
+ENTRYPOINT [ "cotu" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# FROM --platform=$TARGETPLATFORM golang:alpine
-FROM alpine
+FROM --platform=$TARGETPLATFORM golang:alpine
 
 MAINTAINER sntshkmr60@gmail.com
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,9 @@
 pipeline {
     agent any
 
-    // environment {
-    //     DOCKER_ID = credentials('DOCKER_ID')
-    //     DOCKER_PASSWORD = credentials('DOCKER_PASSWORD')
-    // }
+    environment {
+        DOCKER_PASSWORD = credentials('DOCKER_PASSWORD')
+    }
 
     stages {
         stage('Init') {
@@ -12,32 +11,36 @@ pipeline {
                 echo 'Initializing..'
                 echo "Running ${env.BUILD_ID} on ${env.JENKINS_URL}"
                 echo "Current branch: ${env.BRANCH_NAME}"
-                // sh 'echo $DOCKER_PASSWORD | docker login -u $DOCKER_ID --password-stdin'
+                sh 'echo $DOCKER_PASSWORD | docker login -u sntshk --password-stdin'
             }
         }
         stage('Build') {
             steps {
                 echo 'Building image..'
-                // sh 'docker buildx build -t $DOCKER_ID/cotu:latest .'
+                // sh 'docker buildx build -t sntshk/cotu:latest .'
+                sh 'go build -o dist/cotu'
+                sh 'docker build -t sntshk/cotu:golang .'
             }
         }
         stage('Test') {
             steps {
                 echo 'Testing..'
-                // sh 'docker run --rm -e CI=true $DOCKER_ID/cotu pytest'
+                // sh 'docker run --rm -e CI=true sntshk/cotu pytest'
             }
         }
         stage('Publish') {
             steps {
                 echo 'Building and publishing multi-arch image to DockerHub..'
-                // sh 'docker buildx build --push --platform linux/amd64,linux/arm64 -t $DOCKER_ID/cotu:latest .'
+                // sh 'docker buildx build --push --platform linux/amd64,linux/arm64 -t sntshk/cotu:latest .'
+                sh 'docker push sntshk/cotu:golang'
             }
         }
         stage('Cleanup') {
             steps {
                 echo 'Removing unused docker containers and images..'
                 // keep intermediate images as cache, only delete the final image
-                // sh 'docker images -q $DOCKER_ID/cotu | xargs --no-run-if-empty docker rmi'
+                sh 'docker images -q sntshk/cotu | xargs --no-run-if-empty docker rmi'
+                sh 'rm -rf dist/'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 pipeline {
     agent any
 
-    environment {
-        DOCKER_ID = credentials('DOCKER_ID')
-        DOCKER_PASSWORD = credentials('DOCKER_PASSWORD')
-    }
+    // environment {
+    //     DOCKER_ID = credentials('DOCKER_ID')
+    //     DOCKER_PASSWORD = credentials('DOCKER_PASSWORD')
+    // }
 
     stages {
         stage('Init') {
@@ -12,32 +12,32 @@ pipeline {
                 echo 'Initializing..'
                 echo "Running ${env.BUILD_ID} on ${env.JENKINS_URL}"
                 echo "Current branch: ${env.BRANCH_NAME}"
-                sh 'echo $DOCKER_PASSWORD | docker login -u $DOCKER_ID --password-stdin'
+                // sh 'echo $DOCKER_PASSWORD | docker login -u $DOCKER_ID --password-stdin'
             }
         }
         stage('Build') {
             steps {
                 echo 'Building image..'
-                sh 'docker buildx build -t $DOCKER_ID/cotu:latest .'
+                // sh 'docker buildx build -t $DOCKER_ID/cotu:latest .'
             }
         }
         stage('Test') {
             steps {
                 echo 'Testing..'
-                sh 'docker run --rm -e CI=true $DOCKER_ID/cotu pytest'
+                // sh 'docker run --rm -e CI=true $DOCKER_ID/cotu pytest'
             }
         }
         stage('Publish') {
             steps {
                 echo 'Building and publishing multi-arch image to DockerHub..'
-                sh 'docker buildx build --push --platform linux/amd64,linux/arm64 -t $DOCKER_ID/cotu:latest .'
+                // sh 'docker buildx build --push --platform linux/amd64,linux/arm64 -t $DOCKER_ID/cotu:latest .'
             }
         }
         stage('Cleanup') {
             steps {
                 echo 'Removing unused docker containers and images..'
                 // keep intermediate images as cache, only delete the final image
-                sh 'docker images -q $DOCKER_ID/cotu | xargs --no-run-if-empty docker rmi'
+                // sh 'docker images -q $DOCKER_ID/cotu | xargs --no-run-if-empty docker rmi'
             }
         }
     }

--- a/cotu.py
+++ b/cotu.py
@@ -1,6 +1,0 @@
-def hello_world():
-    print("hello world")
-
-
-if __name__ == "__main__":
-    hello_world()

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/santosh/cotu
+
+go 1.19
+
+require github.com/urfave/cli/v2 v2.23.5
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/urfave/cli/v2 v2.23.5 h1:xbrU7tAYviSpqeR3X4nEFWUdB/uDZ6DE+HxmRU7Xtyw=
+github.com/urfave/cli/v2 v2.23.5/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	app := &cli.App{
+		Name:  "cotu",
+		Usage: "developers swiss army knife",
+		Commands: []*cli.Command{
+			{
+				Name:  "s3",
+				Usage: "tasks related to aws s3",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "auth",
+						Usage: "authenticate with aws",
+						Action: func(cCtx *cli.Context) error {
+							fmt.Println("auth with aws in progress")
+							return nil
+						},
+					},
+					{
+						Name:    "upload",
+						Aliases: []string{"u"},
+						Usage:   "upload to a bucket",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:  "bucket",
+								Value: "cotu",
+								Usage: "destination bucket",
+							},
+						},
+						Action: func(cCtx *cli.Context) error {
+							fmt.Println("uploading to s3 in progress")
+							return nil
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-click
-pytest

--- a/test_cotu.py
+++ b/test_cotu.py
@@ -1,8 +1,0 @@
-import cotu
-
-def test_hello_world(capsys):
-    cotu.hello_world()
-    out, err = capsys.readouterr()
-    
-    assert out == 'hello world\n'
-    assert err == ''


### PR DESCRIPTION
We are again going back to Go from Python. We switch from Go to Python because of complexity of `viper` and `cobra` projects. It was also the time I was working with Python more at work.

Now the time have changed. I am primarily working at work on Go. Also, I have found a new CLI library called urfave/cli which seems to be simpler that ever.

Closes #3. 